### PR TITLE
Fix windows build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,5 @@ matrix:
     - os: windows
       script:
         - choco install innounp grep
+        - set -e
         - ./make.bat

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ set(GOBAN_SRC_FILES
         ../src/Metrics.cpp ../src/Metrics.h ../src/GobanOverlay.cpp ../src/GobanOverlay.h ../src/GameState.cpp ../src/GameState.h)
 
 if (WIN32)
-	add_definitions(-DWIN32 -D_WINDOWS)
+    add_definitions(-DWIN32 -D_WINDOWS)
 	option(CMAKE_USE_WIN32_THREADS_INIT "using WIN32 threads" ON)
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:WINDOWS")
 	add_executable(goban WIN32 ${GOBAN_SRC_FILES} ${GOBAN_HDR_FILES} ${SHELL_SRC_FILES} ${GLYPHY_SRC_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ set(GOBAN_SRC_FILES
         ../src/Metrics.cpp ../src/Metrics.h ../src/GobanOverlay.cpp ../src/GobanOverlay.h ../src/GameState.cpp ../src/GameState.h)
 
 if (WIN32)
-    add_definitions(-DWIN32 -D_WINDOWS)
+    add_definitions(-DWIN32 -D_WINDOWS -D_WIN32_WINDOWS=0x0A00)
 	option(CMAKE_USE_WIN32_THREADS_INIT "using WIN32 threads" ON)
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:WINDOWS")
 	add_executable(goban WIN32 ${GOBAN_SRC_FILES} ${GOBAN_HDR_FILES} ${SHELL_SRC_FILES} ${GLYPHY_SRC_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -s")
 endif()
 
 if (WIN32)
+  add_definitions(-DWIN32 -D_WINDOWS -D_WIN32_WINDOWS=0x0A00)
+  option(CMAKE_USE_WIN32_THREADS_INIT "using WIN32 threads" ON)
   set(Boost_USE_STATIC_LIBS ON)
   set(GLEW_USE_STATIC_LIBS ON)
 else()
@@ -164,8 +166,6 @@ set(GOBAN_SRC_FILES
         ../src/Metrics.cpp ../src/Metrics.h ../src/GobanOverlay.cpp ../src/GobanOverlay.h ../src/GameState.cpp ../src/GameState.h)
 
 if (WIN32)
-    add_definitions(-DWIN32 -D_WINDOWS -D_WIN32_WINDOWS=0x0A00)
-	option(CMAKE_USE_WIN32_THREADS_INIT "using WIN32 threads" ON)
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:WINDOWS")
 	add_executable(goban WIN32 ${GOBAN_SRC_FILES} ${GOBAN_HDR_FILES} ${SHELL_SRC_FILES} ${GLYPHY_SRC_FILES})
 else()
@@ -179,6 +179,10 @@ target_link_libraries(goban
     ${OPENGL_LIBRARIES}
     ${GLEW_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
+    ${Boost_SYSTEM_LIBRARY}
+    ${Boost_IOSTREAMS_LIBRARY}
+    ${Boost_THREAD_LIBRARY}
+    ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_LIBRARIES}
     ${CURSES_LIBRARY}
     ${X11_LIBRARIES}

--- a/data/gui/goban.rcss
+++ b/data/gui/goban.rcss
@@ -18,16 +18,16 @@ game {
     display: block;
     width: 100%;
     height: 100%;
-    padding: 0.75em;
+    padding: 0.75rem;
 }
 
 div.grp {
     display:inline;
-    padding-right:0.5em;
+    padding-right:0.5rem;
 }
 div.cmd {
     display:inline;
-    padding-right: 0.5em;
+    padding-right: 0.5rem;
     border-color: #fff; 
 }
 div.fps, div#lblBlack, div#lblWhite, div#cntWhite, div#cntBlack {

--- a/deps/_patches/goban_glyphy.vcxproj
+++ b/deps/_patches/goban_glyphy.vcxproj
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
+    <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
+    <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
@@ -21,20 +21,21 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{16458488-1C9D-4EF0-8311-A5E80ECD25D0}</ProjectGuid>
-    <Keyword>Win32Proj</Keyword>
+    <Keyword>x64Proj</Keyword>
     <RootNamespace>glyphy</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v120</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v120</PlatformToolset>
+    <Platform>x64</Platform>
     <WholeProgramOptimization>
     </WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
@@ -42,15 +43,15 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup />
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>
       </PrecompiledHeader>
@@ -68,7 +69,7 @@
       <Command>cscript "$(MSBuildProjectDirectory)\stringize.js" "$(MSBuildProjectDirectory)\..\src"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>

--- a/deps/make.bat
+++ b/deps/make.bat
@@ -12,7 +12,7 @@ if not exist libRocket git clone https://github.com/libRocket/libRocket.git
 cd libRocket
 if not exist BuildDir mkdir BuildDir
 cd BuildDir
-cmake ../Build -G%STUDIO% -DFREETYPE_INCLUDE_DIRS=../../freetype2/include -DFREETYPE_LIBRARY=../../freetype2/build/Release/freetype
+cmake -G%STUDIO% ../Build -DFREETYPE_INCLUDE_DIRS=../../freetype2/include -DFREETYPE_LIBRARY=../../freetype2/build/Release/freetype
 MSBuild.exe libRocket.sln /t:Build /p:Configuration=Release /p:PlatformToolset=%TOOLSET% /p:TargetPlatformVersion=%TARGET%
 
 cd ..\..

--- a/deps/make.bat
+++ b/deps/make.bat
@@ -1,46 +1,47 @@
-REM freetype 2.9.1
-wget --progress=dot:mega "https://download.savannah.gnu.org/releases/freetype/ft291.zip"
-7z x ft291.zip
-cd freetype-2.9.1
-mkdir build
+REM freetype2
+if not exist freetype2 git clone http://git.sv.nongnu.org/r/freetype/freetype2.git
+cd freetype2
+if not exist build mkdir build
 cd build
-cmake ..
-MSBuild.exe freetype.sln /t:Build /p:Configuration=Release
-
+cmake .. -G%STUDIO%
+MSBuild.exe freetype.vcxproj /t:Build /p:Configuration=Release  /p:PlatformToolset=%TOOLSET% /p:TargetPlatformVersion=%TARGET%
 cd ..\..
 
 REM libRocket
-git clone https://github.com/libRocket/libRocket.git
+if not exist libRocket git clone https://github.com/libRocket/libRocket.git
 cd libRocket
-mkdir BuildDir
+if not exist BuildDir mkdir BuildDir
 cd BuildDir
-cmake ../Build -DFREETYPE_INCLUDE_DIRS=../../freetype-2.9.1/include -DFREETYPE_LIBRARY=../../freetype-2.9.1/build/Release/freetype
-MSBuild.exe libRocket.sln /t:Build /p:Configuration=Release
+cmake ../Build -G%STUDIO% -DFREETYPE_INCLUDE_DIRS=../../freetype2/include -DFREETYPE_LIBRARY=../../freetype2/build/Release/freetype
+MSBuild.exe libRocket.sln /t:Build /p:Configuration=Release /p:PlatformToolset=%TOOLSET% /p:TargetPlatformVersion=%TARGET%
 
 cd ..\..
 
 REM glew
-git clone https://github.com/tamaskenez/glew-with-extensions
+if not exist glew-with-extensions git clone https://github.com/tamaskenez/glew-with-extensions
 cd glew-with-extensions
-mkdir BuildDir
+if not exist BuildDir mkdir BuildDir
 cd BuildDir
-cmake ..\build\cmake -UGLEW_USE_STATIC_LIBS
-MSBuild.exe glew_s.vcxproj /t:Build /p:Configuration=Release
+cmake ..\build\cmake -G%STUDIO% -UGLEW_USE_STATIC_LIBS
+MSBuild.exe glew_s.vcxproj /t:Build /p:Configuration=Release /p:PlatformToolset=%TOOLSET% /p:TargetPlatformVersion=%TARGET%
 
 cd ..\..
 
 REM glm
-git clone https://github.com/g-truc/glm.git
+if not exist glm git clone https://github.com/g-truc/glm.git
 
 REM glyphy
-git clone https://github.com/behdad/glyphy.git
+if not exist glyphy git clone https://github.com/behdad/glyphy.git
 copy _patches\goban_glyphy.vcxproj glyphy\win32
-MSBuild.exe  glyphy\win32\goban_glyphy.vcxproj /t:Build /p:Configuration=Release /p:PlatformToolset=v141
+MSBuild.exe  glyphy\win32\goban_glyphy.vcxproj /t:Build /p:Configuration=Release /p:PlatformToolset=%TOOLSET% /p:TargetPlatformVersion=%TARGET% /p:Platform=x64
 
-::/p:WindowsTargetPlatformVersion=10.0.17763.0
+REM boost-process
+if not exist boost-process git clone https://github.com/BorisSchaeling/boost-process.git
 
 REM boost
-wget --progress=dot:giga https://dl.bintray.com/boostorg/release/1.65.0/binaries/boost_1_65_0-msvc-14.1-32.exe
-innounp -b -q -x boost_1_65_0-msvc-14.1-32.exe {app}\boost\*
-innounp -b -x boost_1_65_0-msvc-14.1-32.exe {app}\lib32-msvc-14.1\libboost_*-vc141-mt-1_65.lib
-move {app} boost
+if not exist boost (
+  if not exist boost_1_65_0-msvc-14.1-64.exe wget --progress=dot:giga https://dl.bintray.com/boostorg/release/1.65.0/binaries/boost_1_65_0-msvc-14.1-64.exe
+  innounp -b -q -x boost_1_65_0-msvc-14.1-64.exe {app}\boost\*
+  innounp -b -x boost_1_65_0-msvc-14.1-64.exe {app}\lib64-msvc-14.1\libboost_*-vc141-mt-1_65.lib 
+  move {app} boost
+)

--- a/make.bat
+++ b/make.bat
@@ -36,8 +36,4 @@ cmake .. -DCMAKE_BUILD_TYPE=Release ^
 	-DFREETYPE_INCLUDE_DIR_ft2build=../deps/freetype-2.9.1/include ^
 	-DFREETYPE_LIBRARY=../deps/freetype-2.9.1/build/Release/freetype
 
-MSBuild.exe goban.sln /t:Build /p:Configuration=Release /p:PlatformToolset=v141
-
-cd ..
-REM copy deps\libRocket\buildDir\Release\Rocket*.dll .
-REM copy build\Release\goban.exe .
+MSBuild.exe goban.sln /t:Build /p:Configuration=Release /p:PlatformToolset=v141 /p:TargetPlatformVersion=10.0.17134.0

--- a/make.bat
+++ b/make.bat
@@ -8,6 +8,9 @@ REM choco install innounp
 set MSBUILD_PATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin"
 set CMAKE_PATH="C:\Program Files\CMake\bin"
 set PATH=%CMAKE_PATH%;%MSBUILD_PATH%;%PATH%
+set TOOLSET=v141
+set TARGET=10.0.17763.0
+set STUDIO="Visual Studio 15 2017 Win64"
 
 set PROJECT_DIR=%~dp0
 set PROJECT_DIR=%PROJECT_DIR:~0,-1%
@@ -20,20 +23,20 @@ REM build goban
 cd %PROJECT_DIR%
 mkdir build
 cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release ^
+cmake .. -G%STUDIO% -DCMAKE_BUILD_TYPE=Release ^
 	-DLIBROCKET_INCLUDE_DIR=../deps/libRocket/Include ^
-	-DGLEW_INCLUDE_DIR=../deps/glew-with-extensions/include ^
-	-DGLEW_LIBRARY=../deps/glew-with-extensions/builddir/lib/Release/libglew32 ^
+	-DGLEW_INCLUDE_DIR="../deps/glew-with-extensions/include" ^
+	-DGLEW_LIBRARY="../deps/glew-with-extensions/builddir/lib/Release/libglew32" ^
 	-DLIBGLYPHY_INCLUDE_DIR=../deps/glyphy/src ^
-	-DLIBGLYPHY_LIBRARY=../deps/glyphy/win32/Release/goban_glyphy.lib ^
+	-DLIBGLYPHY_LIBRARY="../deps/glyphy/win32/x64/Release/goban_glyphy.lib" ^
 	-DBoost_NO_SYSTEM_PATHS=TRUE ^
 	-DBoost_NO_BOOST_CMAKE=TRUE ^
 	-DBOOST_ROOT:PATHNAME="%PROJECT_DIR%\deps\boost" ^
 	-DBOOST_INCLUDEDIR="%PROJECT_DIR%\deps\boost" ^
-	-DBOOST_LIBRARYDIR="%PROJECT_DIR%\deps\boost\lib32-msvc-14.1" ^
-	-DFREETYPE_INCLUDE_DIRS=../deps/freetype-2.9.1/include ^
-	-DFREETYPE_INCLUDE_DIR_freetype2=../deps/freetype-2.9.1/include ^
-	-DFREETYPE_INCLUDE_DIR_ft2build=../deps/freetype-2.9.1/include ^
-	-DFREETYPE_LIBRARY=../deps/freetype-2.9.1/build/Release/freetype
+	-DBOOST_LIBRARYDIR="%PROJECT_DIR%\deps\boost\lib64-msvc-14.1" ^
+	-DFREETYPE_INCLUDE_DIRS=../deps/freetype2/include ^
+	-DFREETYPE_INCLUDE_DIR_freetype2=../deps/freetype2/include ^
+	-DFREETYPE_INCLUDE_DIR_ft2build=../deps/freetype2/include ^
+	-DFREETYPE_LIBRARY=../deps/freetype2/build/Release/freetype
 
-MSBuild.exe goban.sln /t:Build /p:Configuration=Release /p:PlatformToolset=v141 /p:TargetPlatformVersion=10.0.17134.0
+MSBuild.exe goban.sln /t:Build /p:Configuration=Release /p:PlatformToolset=%TOOLSET% /p:TargetPlatformVersion=%TARGET%

--- a/make.bat
+++ b/make.bat
@@ -9,7 +9,7 @@ set MSBUILD_PATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools
 set CMAKE_PATH="C:\Program Files\CMake\bin"
 set PATH=%CMAKE_PATH%;%MSBUILD_PATH%;%PATH%
 set TOOLSET=v141
-set TARGET=10.0.17763.0
+set TARGET=10.0.17134.0
 set STUDIO="Visual Studio 15 2017 Win64"
 
 set PROJECT_DIR=%~dp0

--- a/make.bat
+++ b/make.bat
@@ -36,7 +36,7 @@ cmake .. -DCMAKE_BUILD_TYPE=Release ^
 	-DFREETYPE_INCLUDE_DIR_ft2build=../deps/freetype-2.9.1/include ^
 	-DFREETYPE_LIBRARY=../deps/freetype-2.9.1/build/Release/freetype
 
-MSBuild.exe goban.sln /t:Build /p:Configuration=Release
+MSBuild.exe goban.sln /t:Build /p:Configuration=Release /p:PlatformToolset=v141
 
 cd ..
 REM copy deps\libRocket\buildDir\Release\Rocket*.dll .

--- a/make.bat
+++ b/make.bat
@@ -10,6 +10,7 @@ set CMAKE_PATH="C:\Program Files\CMake\bin"
 set PATH=%CMAKE_PATH%;%MSBUILD_PATH%;%PATH%
 set TOOLSET=v141
 set TARGET=10.0.17134.0
+REM set TARGET=10.0.17763.0
 set STUDIO="Visual Studio 15 2017 Win64"
 
 set PROJECT_DIR=%~dp0


### PR DESCRIPTION
* builds x64 binaries for Windows 10
* using chocolatey distribution of visual studio 2017 workloads
* tested on travis and my desktop pc
* re-added missing boost.project headers dependency
* freetype now linked statically